### PR TITLE
Set World Scale to correct for Engine

### DIFF
--- a/Projects/Android/jni/src/Xash3D/xash3d/engine/client/vid_common.c
+++ b/Projects/Android/jni/src/Xash3D/xash3d/engine/client/vid_common.c
@@ -878,7 +878,7 @@ void GL_InitCommands( void )
 	mp_decals = Cvar_Get( "mp_decals", "300", CVAR_ARCHIVE, "sets the maximum number of decals in multiplayer" );
 
 #ifdef VR
-	vr_worldscale = Cvar_Get( "vr_worldscale", "40", CVAR_ARCHIVE, "Sets the world scale for stereo separation" );
+	vr_worldscale = Cvar_Get( "vr_worldscale", "26.2467", CVAR_ARCHIVE, "Sets the world scale for stereo separation" );
 #endif
 
 	gl_picmip = Cvar_Get( "gl_picmip", "0", CVAR_GLCONFIG, "reduces resolution of textures by powers of 2" );


### PR DESCRIPTION
The Engine (which is a derivative of Quake) uses a very specific unit size:

Wolfenstein 3D, DOOM and QUAKE use the same coordinate/unit system:
8 foot (96 inch) height wall == 64 units, 1.5 inches per pixel unit
1.0 pixel unit / 1.5 inch == 0.666666 pixel units per inch

This make a world scale of: 26.2467